### PR TITLE
Support string or node scrollElement

### DIFF
--- a/src/sticky.js
+++ b/src/sticky.js
@@ -41,7 +41,7 @@ export default class Sticky extends Component {
     hideOnBoundaryHit: PropTypes.bool,
     disabled: PropTypes.bool,
     boundaryElement: PropTypes.string,
-    scrollElement: PropTypes.string,
+    scrollElement: PropTypes.any,
     bottomOffset: PropTypes.number,
     topOffset: PropTypes.number,
     positionRecheckInterval: PropTypes.number,
@@ -96,8 +96,9 @@ export default class Sticky extends Component {
         // and in fact there is no point in such a case
         this.boundaryElement = null;
       }
-
-      this.scrollElement = find(scrollElement, me);
+      this.scrollElement = scrollElement
+      if (typeof scrollElement == 'string')
+        this.scrollElement = find(scrollElement, me);      
 
       if (this.scrollElement) {
         listen(this.scrollElement, ['scroll'], this.checkPosition)


### PR DESCRIPTION
I'm hosting a Sticky instance in an iframe using https://github.com/ryanseddon/react-frame-component and needed to pass the Window object of the iframe to Sticky as scrollElement, as I think Portals are being used and its window context is the parent, not the iframe, so getting wrong scroll events.

This change allows passing in string or object (DOM node)

