### PR TITLE
Fix jumping when using boundaryElement while hideOnBoundaryHit = false

### DIFF
--- a/src/render-props-version.js
+++ b/src/render-props-version.js
@@ -223,7 +223,7 @@ class Sticky extends Component<RenderProps, State> {
       return false
     }
 
-    if (boundaryRect && !isIntersecting(boundaryRect, scrollRect, topOffset, bottomOffset)) {
+    if (hideOnBoundaryHit && boundaryRect && !isIntersecting(boundaryRect, scrollRect, topOffset, bottomOffset)) {
       return false
     }
 

--- a/src/render-props-version.js
+++ b/src/render-props-version.js
@@ -26,10 +26,17 @@ const buildTopStyles = (container, props): StickyStyles => {
   const { bottomOffset, hideOnBoundaryHit } = props;
   const { top, height, width, boundaryBottom } = container;
 
+  // above boundary
   if (hideOnBoundaryHit || (top + height + bottomOffset < boundaryBottom)) {
     return { top: `${top}px`, width: `${width}px`, position: 'fixed' };
   }
 
+  // reaching boundary
+  if (!hideOnBoundaryHit && boundaryBottom > 0) {
+    return { top: `${boundaryBottom - (top + height + bottomOffset)}px`, width: `${width}px`, position: 'fixed' };
+  }
+
+  // below boundary
   return { width: `${width}px`, bottom: `${bottomOffset}px`, position: 'absolute' };
 };
 


### PR DESCRIPTION
This prevents "jumping" when using a `boundaryElement` is set: jumping occurs when element is set to fixed (it quickly gets hidden while fixed is applied).

This also prevent hiding element when reaching boundary when `hideOnBoundaryHit` is set to false (in my case it occurred despite `position: relative` set to the boundary element).
