### PR TITLE
Take top distance into account when hideOnBoundaryHit is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,22 +173,21 @@ app.jsx
 Look at the [Basic Demo](https://rawgit.com/gm0t/react-sticky-el/master/storybook-static/index.html?path=/story/offsets--bottom-offset) for an example
 
 #### hideOnBoundaryHit _(default: true)_
-If `false` then boundaryEl should have position: relative. In this case sticky element won't disappear on reaching it's boundaries. A configuration like this is implemented below.
+If `false` then the sticky element won't disappear on reaching it's boundaries. A configuration like this is implemented below.
 <br />
 ```js
   import Sticky from 'react-sticky-el';
   
-  <div className = "block"  >
+  <div className="block">
 
-    <Sticky boundaryElement=".block" style = {{position: 'relative'}} hideOnBoundaryHit={false}>
-    <SomeChild />
-
+    <Sticky boundaryElement=".block" hideOnBoundaryHit={false}>
+      <SomeChild />
     </Sticky>
   </div>
-
 ```
-
 Look at the [Basic Demo](https://rawgit.com/gm0t/react-sticky-el/master/storybook-static/index.html) for an example.
+
+Note: If the `scrollareaElement` is not at the top of the viewport, when the sticky element overflows it, it will stay visible. This can not be fixed with `overflow: hidden` because the sticky element has `position: fixed` and it's relative to the viewport. A solution is to use `clip-path: inset(0 0 0 0);` on the `scrollareaElement`. **This may have unforeseen consequences with other styles in your app - use caution**. You can see this happening in [this example](https://rawgit.com/gm0t/react-sticky-el/master/storybook-static/index.html?path=/story/hideonboundaryhit--hide-on-boundary-hit-4)
 
 #### dontUpdateHolderHeightWhenSticky _(default: false)_
 
@@ -198,7 +197,7 @@ Look at the [Demo](https://rawgit.com/gm0t/react-sticky-el/master/storybook-stat
 
 
 #### Other props
-All other props (such as className, style, etc..) will be applyed to the `holder` element.
+All other props (such as className, style, etc..) will be applied to the `holder` element.
 
 
 ## Advanced usage

--- a/src/render-props-version.js
+++ b/src/render-props-version.js
@@ -33,7 +33,7 @@ const buildTopStyles = (container, props): StickyStyles => {
 
   // reaching boundary
   if (!hideOnBoundaryHit && boundaryBottom > 0) {
-    return { top: `${boundaryBottom - (top + height + bottomOffset)}px`, width: `${width}px`, position: 'fixed' };
+    return { top: `${boundaryBottom - height - bottomOffset}px`, width: `${width}px`, position: 'fixed' };
   }
 
   // below boundary

--- a/stories/examples.scss
+++ b/stories/examples.scss
@@ -45,6 +45,11 @@ h1, h2 {
     height: 100%;
     overflow-y: scroll;
     position: relative;
+
+    &--distant {
+      margin-top: 100px;
+      border-top: 2px solid blue;
+    }
   }
 }
 

--- a/stories/hiding.story.js
+++ b/stories/hiding.story.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Wrapper, createBlocks } from "./common";
 
 export default {
@@ -51,5 +51,48 @@ export const HideOnBoundaryHit3 = () => (
 
 HideOnBoundaryHit3.story = {
   name: 'false',
+};
+
+export const HideOnBoundaryHit4 = () => {
+  const [ useClipPath, setUseClipPath ] = useState(false);
+
+  return (
+    <Wrapper>
+      <div className="container">
+        <div className="column">
+          <div
+            className="scroll-area scroll-area--distant"
+            style={useClipPath ? { clipPath: 'inset(0 0 0 0)'} : undefined}
+          >
+            <p>
+              If the <code>scrollareaElement</code> is not at the top of the
+              viewport (shown here with 100px margin), when the sticky element
+              overflows it, it will stay visible (try scrolling).
+            </p>
+            <p>
+              You can use <code>clip-path: inset(0 0 0 0);</code> on the{' '}
+              <code>scrollareaElement</code> to solve this but may have
+              unintended consequences.
+            </p>
+            <p>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={useClipPath}
+                  onChange={() => setUseClipPath(!useClipPath)}
+                />
+                  Use clip path
+                </label>
+            </p>
+            {createBlocks(false, 0, 0, false)}
+          </div>
+        </div>
+      </div>
+    </Wrapper>
+)
+};
+
+HideOnBoundaryHit4.story = {
+  name: 'overflow',
 };
 


### PR DESCRIPTION
Addresses issue https://github.com/gm0t/react-sticky-el/issues/67
Also adds documentation and a story example about the `clip-path` option.

@gm0t Let me know what you think.