### PR TITLE
make wrapper unsticky when disabled prop becomes true

### DIFF
--- a/src/render-props-version.js
+++ b/src/render-props-version.js
@@ -156,7 +156,7 @@ class Sticky extends Component<RenderProps, State> {
 
     if (disabled) {
       if (this.state.isFixed) {
-        this.setState({ isFixed: false })
+        this.setState({ isFixed: false, wrapperStyles: {} })
       }
       return
     }


### PR DESCRIPTION
Currently when disabled property becomes true the `wrapperStyles` state
is not reset to empty.

This means that if the disabled property is changed while the
stickyness was active the wrapper wrongly keeps the fixed position.